### PR TITLE
fix: :bug: fix plate shifting of swal in setting page

### DIFF
--- a/src/components/TheActorSetting.vue
+++ b/src/components/TheActorSetting.vue
@@ -2,6 +2,7 @@
 import { NOTIFICATION_TIMEOUT } from '@/config';
 import { useSweetAlert } from '@/hooks/useSweetAlert';
 import { updateActor } from '@/services/actors';
+import { useNotificationStore } from '@/stores/notification';
 import type { Actor } from '@/types';
 import { set } from '@vueuse/core';
 import { useField, useForm } from 'vee-validate';
@@ -19,6 +20,7 @@ const emit = defineEmits<{
 }>();
 
 const { fire } = useSweetAlert();
+const notification = useNotificationStore();
 
 // TODO: file 格式的檢查，再研究看看，真不行，就混合 vuetify3 的檢查
 const { handleSubmit, setFieldValue } = useForm({
@@ -55,12 +57,7 @@ const OnClick = async () => {
   if (!props.actor) return;
 
   await navigator.clipboard.writeText(props.actor.uuid);
-  await fire({
-    title: '複製成功',
-    icon: 'success',
-    timer: NOTIFICATION_TIMEOUT,
-    showConfirmButton: false,
-  });
+  notification.fire('複製成功', 'top');
 };
 
 const onChange = (event: any) => {


### PR DESCRIPTION
use snackbar instead

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

[redmine issue](https://redmine.kingkit.codes/issues/7059)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

1. 原本用 swal，但不知道為什麼會跑版，所以改用 snackbar
2. 用成了 `description` 的錯誤訊息了，改回來就正常了

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

1. 點複製 ID 跳出成功訊息時，畫面會整個往左移，右邊出現一條黑底。
<img width="1393" alt="Screen Shot 2023-07-27 at 11 00 45 PM" src="https://github.com/webduinoio/pluto-frontend/assets/34542533/3218ffab-026f-4fc6-a749-2e1ebbfc0d40">

3. 小書僮名稱沒有填、超過字數，應該要有錯誤提示，目前測試機沒有提示。
<img width="453" alt="Screen Shot 2023-07-27 at 11 01 53 PM" src="https://github.com/webduinoio/pluto-frontend/assets/34542533/59830602-f1ce-4bda-8612-c6a0258e63d7">

<img width="438" alt="Screen Shot 2023-07-27 at 11 01 42 PM" src="https://github.com/webduinoio/pluto-frontend/assets/34542533/730b189f-c220-4326-9826-7c8c412a8e15">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
